### PR TITLE
Fix theme exports

### DIFF
--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -70,4 +70,4 @@ const theme = extendTheme({
   },
 })
 
-export { theme } 
+export default theme;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { AppProps } from 'next/app'
 import { ChakraProvider } from '@chakra-ui/react'
-import { theme } from '../lib/theme'
+import theme from '../lib/theme'
 
 export default function App({ Component, pageProps }: AppProps) {
   return (


### PR DESCRIPTION
## Summary
- export default theme from theme provider
- adjust `_app` import accordingly

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find module '@chakra-ui/react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683ea5798f7c83318511fdae58376dce